### PR TITLE
Support Python >=3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tqdm==4.66.5
-pillow==10.3.0
+pillow==10.4.0
 matplotlib==3.8.0
 requests==2.32.3


### PR DESCRIPTION
Pillow versions < 10.4.0 don't support Python 3.13.